### PR TITLE
fix(ui): prevent path traversal in static file serving

### DIFF
--- a/src/services/ui-manager.js
+++ b/src/services/ui-manager.js
@@ -29,7 +29,13 @@ export { broadcastEvent, initializeUIManagement, handleUploadOAuthCredentials, u
  */
 export async function serveStaticFiles(pathParam, res) {
     // 1. 尝试从系统 static 目录服务
-    let filePath = path.join(process.cwd(), 'static', pathParam === '/' || pathParam === '/index.html' ? 'index.html' : pathParam.replace('/static/', ''));
+    const staticDir = path.resolve(process.cwd(), 'static');
+    let filePath = path.resolve(staticDir, pathParam === '/' || pathParam === '/index.html' ? 'index.html' : pathParam.replace('/static/', ''));
+
+    // Prevent path traversal - ensure resolved path is within the static directory
+    if (!filePath.startsWith(staticDir + path.sep) && filePath !== staticDir) {
+        return false;
+    }
 
     if (!existsSync(filePath)) {
         // 2. 尝试从插件目录服务


### PR DESCRIPTION
## Vulnerability: Path Traversal in Static File Serving (CWE-22)

**Affected file:** `src/services/ui-manager.js` — `serveStaticFiles()` function

### Summary

The `serveStaticFiles` function constructs a file path using `path.join()` with user-supplied URL path segments. Because `path.join()` resolves `..` sequences but does not constrain the result to a base directory, an attacker can escape the `static/` directory and read arbitrary files from the server's filesystem.

This endpoint is reached **without authentication**. In `src/handlers/request-handler.js` (line ~121), any request matching a UI static prefix (e.g. `/static/`) is routed directly to `serveStaticFiles()` before any auth middleware runs. The `UI_ENABLED` config defaults to `true`.

### Data Flow

1. HTTP request arrives with path `/static/../../etc/passwd`
2. `isUIPath(path)` returns `true` (path starts with `/static/`)
3. `serveStaticFiles(path, res)` is called — no authentication check
4. `pathParam.replace('/static/', '')` yields `../../etc/passwd`
5. `path.join(process.cwd(), 'static', '../../etc/passwd')` resolves to `/etc/passwd`
6. `existsSync(filePath)` succeeds, file contents are served to the attacker

### Proof of Concept

```bash
# Read /etc/passwd from the server (default config, UI_ENABLED=true)
curl -s "http://localhost:3456/static/..%2F..%2F..%2F..%2Fetc%2Fpasswd"

# Read the application's own environment/config
curl -s "http://localhost:3456/static/..%2F..%2F.env"

# Read package.json to confirm traversal works
curl -s "http://localhost:3456/static/..%2Fpackage.json"
```

The `%2F` encoding is used because many HTTP clients and some proxies normalize bare `../` in URLs, but the Node.js HTTP server receives the decoded path. Depending on the deployment, bare `../` may also work directly.

### Fix Description

The fix replaces `path.join()` with `path.resolve()` and adds a directory containment check:

```js
const staticDir = path.resolve(process.cwd(), 'static');
let filePath = path.resolve(staticDir, /* user input */);

if (!filePath.startsWith(staticDir + path.sep) && filePath !== staticDir) {
    return false;
}
```

`path.resolve()` produces an absolute canonical path (no `..` remaining), and the `startsWith` check ensures the resolved path is still within the intended `static/` directory. If traversal is detected, the function returns `false` and the request falls through to a 404 — no file contents are leaked.

### Testing

- Verified that `curl "http://localhost:3456/static/..%2F..%2Fetc%2Fpasswd"` returns a 404 after the fix (previously returned file contents)
- Verified that normal static file serving still works: `curl "http://localhost:3456/static/index.html"` returns the UI page
- Verified edge cases: double-encoded sequences, Windows-style backslash separators, and trailing slashes are all handled correctly by `path.resolve()`

### Adversarial Review

Before submitting, we verified this is not mitigated by other layers. The request handler serves static files before any authentication middleware executes (line 121 in `request-handler.js`). There is no reverse proxy path normalization assumed in the codebase — the app is designed to run standalone via `node`. The `isUIPath` check only validates that the path *starts with* a known prefix, it does not sanitize traversal sequences. No existing input validation prevents this attack.