### PR TITLE
feat: add current MiniMax models

### DIFF
--- a/src/providers/openai/iflow-core.js
+++ b/src/providers/openai/iflow-core.js
@@ -28,7 +28,7 @@ import * as crypto from 'crypto';
 import { configureAxiosProxy } from '../../utils/proxy-utils.js';
 import { isRetryableNetworkError, MODEL_PROVIDER, formatExpiryLog, getRetryAfterMs } from '../../utils/common.js';
 import { getProviderPoolManager } from '../../services/service-manager.js';
-import { getProviderModels } from '../provider-models.js';
+import { getProviderModels, IFLOW_MANUAL_MODELS } from '../provider-models.js';
 
 // iFlow API 端点
 const IFLOW_API_BASE_URL = 'https://apis.iflow.cn/v1';
@@ -1118,7 +1118,7 @@ export class IFlowApiService {
         }
         
         // 需要手动添加的模型列表
-        const manualModels = ['glm-4.7', 'glm-5', 'kimi-k2.5', 'minimax-m2.1', 'minimax-m2.5'];
+        const manualModels = IFLOW_MANUAL_MODELS;
         
         try {
             const response = await this.axiosInstance.get('/models', {

--- a/src/providers/provider-models.js
+++ b/src/providers/provider-models.js
@@ -2,6 +2,16 @@ import { convertData } from '../convert/convert.js';
 import { MODEL_PROVIDER } from '../utils/common.js';
 import { CONFIG } from '../core/config-manager.js';
 
+export const IFLOW_MANUAL_MODELS = [
+    'glm-4.7',
+    'glm-5',
+    'kimi-k2.5',
+    'MiniMax-M3',
+    'MiniMax-M2.7',
+    'minimax-m2.1',
+    'minimax-m2.5'
+];
+
 /**
  * 获取模型配置元数据
  * @param {string} modelId - 模型 ID 或别名
@@ -119,11 +129,7 @@ export const PROVIDER_MODELS = {
         'deepseek-r1',
         'deepseek-v3',
         // 手动定义
-        'glm-4.7',
-        'glm-5',
-        'kimi-k2.5',
-        'minimax-m2.1',
-        'minimax-m2.5',
+        ...IFLOW_MANUAL_MODELS,
     ],
     'openai-codex-oauth': [
         'gpt-5.3-codex-spark',

--- a/tests/minimax-model-registry.test.js
+++ b/tests/minimax-model-registry.test.js
@@ -1,0 +1,22 @@
+import {
+    getProviderModels,
+    IFLOW_MANUAL_MODELS
+} from '../src/providers/provider-models.js';
+
+describe('MiniMax model registry', () => {
+    test('includes the current MiniMax models', () => {
+        const models = getProviderModels('openai-iflow');
+
+        expect(models).toEqual(expect.arrayContaining([
+            'MiniMax-M3',
+            'MiniMax-M2.7'
+        ]));
+    });
+
+    test('supplements upstream model responses from the same registry source', () => {
+        expect(IFLOW_MANUAL_MODELS).toEqual(expect.arrayContaining([
+            'MiniMax-M3',
+            'MiniMax-M2.7'
+        ]));
+    });
+});


### PR DESCRIPTION
Reason: Add MiniMax-M3 and MiniMax-M2.7 to the model registry.

## Summary

- Register MiniMax-M3 and MiniMax-M2.7 in the existing model catalog.
- Reuse the registry source when supplementing model-list responses.
- Cover both registry paths with focused unit tests.

## Checks

- `npm test -- --runInBand tests/minimax-model-registry.test.js --silent`
- `node --check src/providers/provider-models.js && node --check src/providers/openai/iflow-core.js && node --check tests/minimax-model-registry.test.js && git diff --check`
