### PR TITLE
docs: 修复README中的Star历史图表链接

### DIFF
--- a/README-JA.md
+++ b/README-JA.md
@@ -847,7 +847,7 @@ AIClient2APIプロジェクトに貢献してくれたすべての開発者に�
 ### 🌟 Star History
 
 
-[![Star History Chart](https://api.star-history.com/svg?repos=justlovemaki/AIClient-2-API&type=Timeline)](https://www.star-history.com/#justlovemaki/AIClient-2-API&Timeline)
+[![Star History Chart](https://star-history.dera.page/svg?repos=justlovemaki/AIClient-2-API&type=Timeline)](https://star-history.dera.page/#justlovemaki/AIClient-2-API&Timeline)
 
 ---
 

--- a/README-ZH.md
+++ b/README-ZH.md
@@ -869,7 +869,7 @@ OAuth 令牌（如 Gemini, Antigravity, Codex）通常有一定的有效期（�
 ### 🌟 Star History
 
 
-[![Star History Chart](https://api.star-history.com/svg?repos=justlovemaki/AIClient-2-API&type=Timeline)](https://www.star-history.com/#justlovemaki/AIClient-2-API&Timeline)
+[![Star History Chart](https://star-history.dera.page/svg?repos=justlovemaki/AIClient-2-API&type=Timeline)](https://star-history.dera.page/#justlovemaki/AIClient-2-API&Timeline)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -846,7 +846,7 @@ Thanks to all the developers who contributed to the AIClient2API project:
 ### 🌟 Star History
 
 
-[![Star History Chart](https://api.star-history.com/svg?repos=justlovemaki/AIClient-2-API&type=Timeline)](https://www.star-history.com/#justlovemaki/AIClient-2-API&Timeline)
+[![Star History Chart](https://star-history.dera.page/svg?repos=justlovemaki/AIClient-2-API&type=Timeline)](https://star-history.dera.page/#justlovemaki/AIClient-2-API&Timeline)
 
 ---
 


### PR DESCRIPTION
当前README中的Star历史图表因数据源接口限制已无法正常加载，影响了项目的展示效果。本PR将三个语言版本README中的Star历史图表链接修复为新域名，使图表能够正常显示。