### PR TITLE
fix(antigravity,converters): update UA to 2.8.1, sanitize enum for Gemini, and ensure OpenAI stream ends with [DONE]

### DIFF
--- a/src/converters/strategies/ClaudeConverter.js
+++ b/src/converters/strategies/ClaudeConverter.js
@@ -1201,24 +1201,32 @@ export class ClaudeConverter extends BaseConverter {
      */
     cleanUrlFormatFromSchema(schema) {
         if (!schema || typeof schema !== 'object') return;
-        
+
+        // Gemini 只接受字符串枚举值：过滤非字符串元素，过滤后为空则移除 enum
+        if (Array.isArray(schema.enum)) {
+            schema.enum = schema.enum.filter(v => typeof v === 'string');
+            if (schema.enum.length === 0) {
+                delete schema.enum;
+            }
+        }
+
         // 如果是属性对象，检查并清理 format
         if (schema.type === 'string' && schema.format === 'uri') {
             delete schema.format;
         }
-        
+
         // 递归处理 properties
         if (schema.properties && typeof schema.properties === 'object') {
             Object.values(schema.properties).forEach(prop => {
                 this.cleanUrlFormatFromSchema(prop);
             });
         }
-        
+
         // 递归处理 items（数组类型）
         if (schema.items) {
             this.cleanUrlFormatFromSchema(schema.items);
         }
-        
+
         // 递归处理 additionalProperties
         if (schema.additionalProperties && typeof schema.additionalProperties === 'object') {
             this.cleanUrlFormatFromSchema(schema.additionalProperties);

--- a/src/converters/utils.js
+++ b/src/converters/utils.js
@@ -286,6 +286,17 @@ function cleanJsonSchemaGeneric(schema, options, recursiveFn) {
             continue;
         }
 
+        // 处理 enum：Gemini 要求枚举元素为字符串（仅 sanitizeEnum 模式）
+        if (key === 'enum' && options.sanitizeEnum) {
+            if (Array.isArray(value)) {
+                const strEnum = value.filter(v => typeof v === 'string');
+                if (strEnum.length > 0) {
+                    sanitized[key] = strEnum;
+                }
+            }
+            continue;
+        }
+
         // 处理 properties
         if (key === 'properties' && typeof value === 'object' && value !== null) {
             sanitized[key] = cleanPropertiesRecursively(value, recursiveFn);
@@ -327,7 +338,8 @@ export function cleanJsonSchemaProperties(schema) {
         schema,
         {
             allowedKeys: GEMINI_ALLOWED_KEYS,
-            typeHandler: handleGeminiTypeField
+            typeHandler: handleGeminiTypeField,
+            sanitizeEnum: true
         },
         cleanJsonSchemaProperties
     );

--- a/src/providers/gemini/antigravity-core.js
+++ b/src/providers/gemini/antigravity-core.js
@@ -32,7 +32,7 @@ const ANTIGRAVITY_BASE_URL_PROD = 'https://cloudcode-pa.googleapis.com';
 const ANTIGRAVITY_API_VERSION = 'v1internal';
 const OAUTH_CLIENT_ID = '1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com';
 const OAUTH_CLIENT_SECRET = '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';
-const DEFAULT_USER_AGENT = 'antigravity/1.104.0 darwin/arm64';
+const DEFAULT_USER_AGENT = 'antigravity/2.8.1 darwin/arm64';
 const REFRESH_SKEW = 3000; // 3000秒（50分钟）提前刷新Token
 
 const ANTIGRAVITY_SYSTEM_PROMPT = `You are Antigravity, a powerful agentic AI coding assistant designed by the Google Deepmind team working on Advanced Agentic Coding.You are pair programming with a USER to solve their coding task. The task may require creating a new codebase, modifying or debugging an existing codebase, or simply answering a question.**Absolute paths only****Proactiveness**`;

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -1289,10 +1289,9 @@ export async function handleStreamRequest(res, service, model, requestBody, from
             if (!res.writableEnded) {
                 try {
                     if (clientProtocol === MODEL_PROTOCOL_PREFIX.OPENAI) {
-                        if (!hasMessageStop) {
-                            res.write('data: [DONE]\n\n');
-                            hasMessageStop = true;
-                        }
+                        // OpenAI 规范：无论是否已有 finish_reason chunk，都必须以 [DONE] 收尾
+                        res.write('data: [DONE]\n\n');
+                        hasMessageStop = true;
                     } else if (clientProtocol === MODEL_PROTOCOL_PREFIX.OPENAI_RESPONSES) {
                         // OpenAI Responses 以 response.completed/response.incomplete（或 error）作为结束事件。
                         // 连接关闭即表示流结束；不要再追加 `event: done` + `data: {}`，否则会触发下游类型校验失败（AI_TypeValidationError）。


### PR DESCRIPTION
This PR includes commit 3e08c67 from Au3C2/AIClient2API with three fixes:

- **Bump DEFAULT_USER_AGENT to `antigravity/2.8.1 darwin/arm64`** in `src/providers/gemini/antigravity-core.js` to enable gemini-3.7-* models on the Google upstream.
- **Sanitize JSON schema enum to strings only** in `ClaudeConverter` and `converters/utils` (`sanitizeEnum` option) for Gemini protocol compatibility.
- **Always send `data: [DONE]`** at the end of OpenAI streaming responses regardless of previous finish_reason in `src/utils/common.js`.

Files changed: 4 files, +29/-10.