### PR TITLE
fix(stream): 忽略 SSE 注释与 keepalive 保活行避免 JSON 解析错误

### DIFF
--- a/src/providers/grok/grok-cli-core.js
+++ b/src/providers/grok/grok-cli-core.js
@@ -2463,11 +2463,11 @@ export class GrokCliApiService {
 
     parseSSELine(line) {
         const trimmedLine = String(line || '').trim();
-        if (!trimmedLine || trimmedLine.startsWith('event: ') || trimmedLine.startsWith('id: ') || trimmedLine.startsWith('retry: ')) {
+        if (!trimmedLine || trimmedLine.startsWith(':') || trimmedLine.startsWith('event:') || trimmedLine.startsWith('id:') || trimmedLine.startsWith('retry:')) {
             return null;
         }
 
-        const dataStr = trimmedLine.startsWith('data: ') ? trimmedLine.slice(6).trim() : trimmedLine;
+        const dataStr = trimmedLine.startsWith('data:') ? trimmedLine.slice(5).trim() : trimmedLine;
         if (!dataStr || dataStr === '[DONE]') return null;
 
         try {

--- a/src/providers/grok/grok-core.js
+++ b/src/providers/grok/grok-core.js
@@ -1323,8 +1323,8 @@ export class GrokApiService {
 
             for await (const line of rl) {
                 const trimmed = line.trim();
-                if (!trimmed) continue;
-                let dataStr = trimmed.startsWith('data: ') ? trimmed.slice(6).trim() : trimmed;
+                if (!trimmed || trimmed.startsWith(':')) continue;
+                let dataStr = trimmed.startsWith('data:') ? trimmed.slice(5).trim() : trimmed;
                 if (dataStr === '[DONE]') break;
                 try {
                     const json = JSON.parse(dataStr);

--- a/src/providers/openai/codex-core.js
+++ b/src/providers/openai/codex-core.js
@@ -103,8 +103,7 @@ function parseCodexRetryAfterMs(errorBody) {
 
 function extractSSEData(line) {
     const trimmedLine = String(line || '').trim();
-    if (!trimmedLine) return null;
-    if (trimmedLine.startsWith('event: ') || trimmedLine.startsWith('id: ') || trimmedLine.startsWith('retry: ')) {
+    if (!trimmedLine || trimmedLine.startsWith(':') || trimmedLine.startsWith('event:') || trimmedLine.startsWith('id:') || trimmedLine.startsWith('retry:')) {
         return null;
     }
     if (trimmedLine.startsWith('data:')) {


### PR DESCRIPTION
## Summary

- 过滤并忽略以冒号 `:` 开头的 SSE 注释行 / 保活心跳行（例如 `: keepalive`、`: ping`、`:` 等）
- 规范化 `data:`、`event:`、`id:`、`retry:` 等前缀判断与解析逻辑
- 修复 Grok CLI (`grok-cli-core.js`)、Codex (`codex-core.js`) 及 Grok Web (`grok-core.js`) 在接收 SSE 心跳帧时的 JSON 解析报错

## Problem

在 SSE (Server-Sent Events) 规范中，以冒号 `:` 开头的行为注释行（常用于服务端/代理保活心跳）。
Grok CLI 等上游在流式等待或思考期间会发送 `: keepalive`。由于此前未过滤冒号开头的注释行，导致这部分内容被作为数据行传入 `JSON.parse`，触发如下报错：

```text
[ERROR] [Grok CLI] Failed to parse SSE data: Unexpected token ':', ": keepalive" is not valid JSON
```

## Changes

1. **`src/providers/grok/grok-cli-core.js`**: `parseSSELine` 增加对 `line.startsWith(':')` 的过滤，规范化 `data:` 前缀截取。
2. **`src/providers/openai/codex-core.js`**: `extractSSEData` 增加对 `line.startsWith(':')` 的过滤。
3. **`src/providers/grok/grok-core.js`**: 在流式处理循环中提前跳过 `startsWith(':')` 的行，避免不必要的 `JSON.parse` 异常开销。

## Verification

已验证以下常见 SSE 场景的解析行为：
- `: keepalive` / `: ping` -> 正常识别并忽略（返回 `null` / 跳过）
- `event: ping` -> 正常识别并忽略
- `data: {"type":"response.text.delta"}` / `data:{"type":"response.text.delta"}` -> 正常解析为 JSON 对象
- `data: [DONE]` -> 正常识别结束标记