### PR TITLE
fix(kiro): handle profileArn for IdC and Builder ID

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "test:unit": "node run-tests.js --unit",
     "test:integration": "node run-tests.js --integration",
     "test:summary": "node test-summary.js",
+    "test:kiro-profile-arn": "node --test --test-force-exit tests/kiro-profile-arn.node.test.mjs",
     "help": "node src/scripts/help.js",
     "example:api": "node src/scripts/example-api.js"
   }

--- a/src/providers/claude/claude-kiro.js
+++ b/src/providers/claude/claude-kiro.js
@@ -671,6 +671,7 @@ export class KiroApiService {
         this.axiosInstance = null; // Initialize later in async method
         this.axiosSocialRefreshInstance = null;
         this._tokenRefreshPromise = null;
+        this._profileArnDiscoveryPromise = null;
     }
  
     async initialize() {
@@ -924,6 +925,80 @@ async saveCredentialsToFile(filePath, newData) {
 };
 
     /**
+     * Discover and persist the real profile ARN for IdC / Builder ID credentials.
+     */
+    async ensureProfileArn() {
+        if (this.profileArn) return this.profileArn;
+
+        if (this.authMethod === KIRO_CONSTANTS.AUTH_METHOD_SOCIAL) {
+            return null;
+        }
+
+        if (!this.accessToken) {
+            throw new Error('Cannot discover Kiro profileArn without an access token.');
+        }
+
+        if (this._profileArnDiscoveryPromise) {
+            return this._profileArnDiscoveryPromise;
+        }
+
+        this._profileArnDiscoveryPromise = (async () => {
+            const regions = [...new Set([
+                this.region,
+                this.idcRegion,
+                'us-east-1',
+                'eu-central-1'
+            ].filter(Boolean))];
+            let lastError = null;
+
+            for (const region of regions) {
+                const axiosConfig = {
+                    method: 'post',
+                    url: `https://q.${region}.amazonaws.com/`,
+                    headers: {
+                        'Content-Type': 'application/x-amz-json-1.0',
+                        'x-amz-target': 'AmazonCodeWhispererService.ListAvailableProfiles',
+                        'Authorization': `Bearer ${this.accessToken}`,
+                        'amz-sdk-invocation-id': uuidv4(),
+                        'amz-sdk-request': 'attempt=1; max=1',
+                        'Connection': 'close'
+                    },
+                    data: { maxResults: 10 }
+                };
+                this._applySidecar(axiosConfig);
+
+                try {
+                    const response = await this.axiosInstance.request(axiosConfig);
+                    const profileArn = response.data?.profiles
+                        ?.map(profile => profile?.arn)
+                        .find(arn => typeof arn === 'string' && arn.length > 0);
+
+                    if (!profileArn) continue;
+
+                    this.profileArn = profileArn;
+                    const tokenFilePath = this.credsFilePath || path.join(this.credPath, KIRO_AUTH_TOKEN_FILE);
+                    await this.saveCredentialsToFile(tokenFilePath, { profileArn });
+                    logger.info(`[Kiro Auth] Discovered and persisted profileArn for ${this.authMethod || 'IdC'} credentials.`);
+                    return profileArn;
+                } catch (error) {
+                    lastError = error;
+                }
+            }
+
+            const detail = lastError?.response?.data?.message
+                || lastError?.message
+                || 'no profile returned';
+            throw new Error(`Kiro profileArn is missing and automatic discovery failed: ${detail}`);
+        })();
+
+        try {
+            return await this._profileArnDiscoveryPromise;
+        } finally {
+            this._profileArnDiscoveryPromise = null;
+        }
+    }
+
+    /**
      * 执行实际的 token 刷新操作（内部方法）
      * @param {Function} saveCredentialsToFile - 保存凭证的函数
      * @param {string} tokenFilePath - 凭证文件路径
@@ -1174,6 +1249,7 @@ async saveCredentialsToFile(filePath, newData) {
      * Build CodeWhisperer request from OpenAI messages
      */
     async buildCodewhispererRequest(messages, model, tools = null, inSystemPrompt = null, thinking = null) {
+        await this.ensureProfileArn();
         const conversationId = uuidv4();
         
         // 内置的 systemPrompt 前缀
@@ -1680,7 +1756,7 @@ async saveCredentialsToFile(filePath, newData) {
 
         request.conversationState.currentMessage.userInputMessage = userInputMessage;
 
-        if (this.authMethod === KIRO_CONSTANTS.AUTH_METHOD_SOCIAL) {
+        if (this.profileArn) {
             request.profileArn = this.profileArn;
         }
 
@@ -3540,6 +3616,7 @@ async saveCredentialsToFile(filePath, newData) {
      */
     async getUsageLimits() {
         if (!this.isInitialized) await this.initialize();
+        await this.ensureProfileArn();
 
         // Token 刷新策略：
         // 1. 已过期 → 必须等待刷新
@@ -3563,7 +3640,7 @@ async saveCredentialsToFile(filePath, newData) {
             origin: KIRO_CONSTANTS.ORIGIN_AI_EDITOR,
             resourceType: resourceType
         });
-         if (this.authMethod === KIRO_CONSTANTS.AUTH_METHOD_SOCIAL && this.profileArn) {
+        if (this.profileArn) {
             params.append('profileArn', this.profileArn);
         }
         const fullUrl = `${usageLimitsUrl}?${params.toString()}`;

--- a/src/providers/claude/claude-kiro.js
+++ b/src/providers/claude/claude-kiro.js
@@ -44,6 +44,7 @@ const KIRO_CONSTANTS = {
     CONTENT_TYPE_JSON: 'application/json',
     ACCEPT_JSON: 'application/json',
     AUTH_METHOD_SOCIAL: 'social',
+    BUILDER_ID_PROFILE_ARN: 'arn:aws:codewhisperer:us-east-1:638616132270:profile/AAAACCCCXXXX',
     CHAT_TRIGGER_TYPE_MANUAL: 'MANUAL',
     ORIGIN_AI_EDITOR: 'AI_EDITOR',
     TOTAL_CONTEXT_TOKENS: 200000, // Claude Sonnet 4.5 actual context is 200K
@@ -934,6 +935,8 @@ async saveCredentialsToFile(filePath, newData) {
             return null;
         }
 
+        await this._prepareAccessTokenForRequest('profileArn discovery');
+
         if (!this.accessToken) {
             throw new Error('Cannot discover Kiro profileArn without an access token.');
         }
@@ -950,6 +953,24 @@ async saveCredentialsToFile(filePath, newData) {
                 'eu-central-1'
             ].filter(Boolean))];
             let lastError = null;
+            let refreshedAfterUnauthorized = false;
+            const acceptDiscoveredProfileArn = async (response) => {
+                const profileArn = response.data?.profiles
+                    ?.map(profile => profile?.arn)
+                    .find(arn => typeof arn === 'string' && arn.length > 0);
+
+                if (!profileArn) return null;
+
+                this.profileArn = profileArn;
+                const tokenFilePath = this.credsFilePath || path.join(this.credPath, KIRO_AUTH_TOKEN_FILE);
+                try {
+                    await this.saveCredentialsToFile(tokenFilePath, { profileArn });
+                    logger.info(`[Kiro Auth] Discovered and persisted profileArn for ${this.authMethod || 'IdC'} credentials.`);
+                } catch (error) {
+                    logger.warn(`[Kiro Auth] Discovered profileArn but could not persist it: ${error.message}`);
+                }
+                return profileArn;
+            };
 
             for (const region of regions) {
                 const axiosConfig = {
@@ -969,18 +990,28 @@ async saveCredentialsToFile(filePath, newData) {
 
                 try {
                     const response = await this.axiosInstance.request(axiosConfig);
-                    const profileArn = response.data?.profiles
-                        ?.map(profile => profile?.arn)
-                        .find(arn => typeof arn === 'string' && arn.length > 0);
-
-                    if (!profileArn) continue;
-
-                    this.profileArn = profileArn;
-                    const tokenFilePath = this.credsFilePath || path.join(this.credPath, KIRO_AUTH_TOKEN_FILE);
-                    await this.saveCredentialsToFile(tokenFilePath, { profileArn });
-                    logger.info(`[Kiro Auth] Discovered and persisted profileArn for ${this.authMethod || 'IdC'} credentials.`);
-                    return profileArn;
+                    const profileArn = await acceptDiscoveredProfileArn(response);
+                    if (profileArn) return profileArn;
                 } catch (error) {
+                    const detail = error?.response?.data?.message || error?.message || '';
+                    if (error?.response?.status === 403 && detail.includes('AWS Builder ID is not supported for this operation')) {
+                        this.profileArn = KIRO_CONSTANTS.BUILDER_ID_PROFILE_ARN;
+                        logger.info('[Kiro Auth] Using the Kiro Builder ID profileArn because profile discovery is unsupported.');
+                        return this.profileArn;
+                    }
+                    if (error?.response?.status === 401 && !refreshedAfterUnauthorized) {
+                        refreshedAfterUnauthorized = true;
+                        try {
+                            await this.initializeAuth(true);
+                            axiosConfig.headers.Authorization = `Bearer ${this.accessToken}`;
+                            const retryResponse = await this.axiosInstance.request(axiosConfig);
+                            const profileArn = await acceptDiscoveredProfileArn(retryResponse);
+                            if (profileArn) return profileArn;
+                        } catch (retryError) {
+                            lastError = retryError;
+                            continue;
+                        }
+                    }
                     lastError = error;
                 }
             }
@@ -3640,7 +3671,7 @@ async saveCredentialsToFile(filePath, newData) {
             origin: KIRO_CONSTANTS.ORIGIN_AI_EDITOR,
             resourceType: resourceType
         });
-        if (this.profileArn) {
+        if (this.profileArn && this.profileArn !== KIRO_CONSTANTS.BUILDER_ID_PROFILE_ARN) {
             params.append('profileArn', this.profileArn);
         }
         const fullUrl = `${usageLimitsUrl}?${params.toString()}`;

--- a/tests/kiro-profile-arn.node.test.mjs
+++ b/tests/kiro-profile-arn.node.test.mjs
@@ -21,11 +21,190 @@ test('includes an existing profileArn for Builder ID generation requests', async
     disposeService(service);
 });
 
+test('uses the Kiro Builder ID profile when profile discovery is unsupported', async () => {
+    const service = new KiroApiService({});
+    service.authMethod = 'builder-id';
+    service.accessToken = 'access-token';
+    service.expiresAt = new Date(Date.now() + 60_000).toISOString();
+    service.region = 'us-east-1';
+    const requests = [];
+    service.axiosInstance = {
+        request: async (config) => {
+            requests.push(config);
+            const error = new Error('Request failed with status code 403');
+            error.response = {
+                status: 403,
+                data: { message: 'AWS Builder ID is not supported for this operation.' }
+            };
+            throw error;
+        }
+    };
+    service.saveCredentialsToFile = async () => {};
+
+    const arn = await service.ensureProfileArn();
+
+    assert.equal(arn, 'arn:aws:codewhisperer:us-east-1:638616132270:profile/AAAACCCCXXXX');
+    assert.equal(service.profileArn, arn);
+    assert.equal(requests.length, 1);
+    disposeService(service);
+});
+
+test('refreshes an expired access token before profile discovery', async () => {
+    const service = new KiroApiService({});
+    service.authMethod = 'builder-id';
+    service.accessToken = 'expired-access-token';
+    service.expiresAt = new Date(Date.now() - 60_000).toISOString();
+    service.region = 'us-east-1';
+    let refreshCount = 0;
+    service.initializeAuth = async (forceRefresh) => {
+        assert.equal(forceRefresh, true);
+        refreshCount++;
+        service.accessToken = 'fresh-access-token';
+        service.expiresAt = new Date(Date.now() + 60_000).toISOString();
+    };
+    service.axiosInstance = {
+        request: async (config) => {
+            assert.equal(config.headers.Authorization, 'Bearer fresh-access-token');
+            return {
+                data: {
+                    profiles: [
+                        { arn: 'arn:aws:codewhisperer:us-east-1:123456789012:profile/REAL' }
+                    ]
+                }
+            };
+        }
+    };
+    service.saveCredentialsToFile = async () => {};
+
+    const arn = await service.ensureProfileArn();
+
+    assert.equal(arn, 'arn:aws:codewhisperer:us-east-1:123456789012:profile/REAL');
+    assert.equal(refreshCount, 1);
+    disposeService(service);
+});
+
+test('refreshes and retries profile discovery after an unexpected 401', async () => {
+    const service = new KiroApiService({});
+    service.authMethod = 'builder-id';
+    service.accessToken = 'stale-access-token';
+    service.expiresAt = new Date(Date.now() + 60 * 60_000).toISOString();
+    service.region = 'us-east-1';
+    let refreshCount = 0;
+    let requestCount = 0;
+    service.initializeAuth = async (forceRefresh) => {
+        assert.equal(forceRefresh, true);
+        refreshCount++;
+        service.accessToken = 'fresh-access-token';
+    };
+    service.axiosInstance = {
+        request: async (config) => {
+            requestCount++;
+            if (requestCount === 1) {
+                assert.equal(config.headers.Authorization, 'Bearer stale-access-token');
+                const error = new Error('Request failed with status code 401');
+                error.response = { status: 401, data: { message: 'Unauthorized' } };
+                throw error;
+            }
+            assert.equal(config.headers.Authorization, 'Bearer fresh-access-token');
+            return {
+                data: {
+                    profiles: [
+                        { arn: 'arn:aws:codewhisperer:us-east-1:123456789012:profile/REAL' }
+                    ]
+                }
+            };
+        }
+    };
+    service.saveCredentialsToFile = async () => {};
+
+    const arn = await service.ensureProfileArn();
+
+    assert.equal(arn, 'arn:aws:codewhisperer:us-east-1:123456789012:profile/REAL');
+    assert.equal(refreshCount, 1);
+    assert.equal(requestCount, 2);
+    disposeService(service);
+});
+
+test('does not treat unrelated 403 responses as Builder ID fallback', async () => {
+    const service = new KiroApiService({});
+    service.authMethod = 'builder-id';
+    service.accessToken = 'access-token';
+    service.expiresAt = new Date(Date.now() + 60 * 60_000).toISOString();
+    service.region = 'us-east-1';
+    service.idcRegion = 'us-east-1';
+    service.axiosInstance = {
+        request: async () => {
+            const error = new Error('Request failed with status code 403');
+            error.response = { status: 403, data: { message: 'User is not authorized to make this call.' } };
+            throw error;
+        }
+    };
+
+    await assert.rejects(
+        service.ensureProfileArn(),
+        /Kiro profileArn is missing and automatic discovery failed: User is not authorized/
+    );
+    assert.equal(service.profileArn, undefined);
+    disposeService(service);
+});
+
+test('refreshes at most once when profile discovery keeps returning 401', async () => {
+    const service = new KiroApiService({});
+    service.authMethod = 'builder-id';
+    service.accessToken = 'stale-access-token';
+    service.expiresAt = new Date(Date.now() + 60 * 60_000).toISOString();
+    service.region = 'ap-southeast-1';
+    service.idcRegion = 'eu-west-1';
+    let refreshCount = 0;
+    service.initializeAuth = async () => {
+        refreshCount++;
+        service.accessToken = 'fresh-access-token';
+    };
+    service.axiosInstance = {
+        request: async () => {
+            const error = new Error('Request failed with status code 401');
+            error.response = { status: 401, data: { message: 'Unauthorized' } };
+            throw error;
+        }
+    };
+
+    await assert.rejects(service.ensureProfileArn(), /Unauthorized/);
+    assert.equal(refreshCount, 1);
+    disposeService(service);
+});
+
+test('uses a discovered profileArn when credential persistence fails', async () => {
+    const service = new KiroApiService({});
+    service.authMethod = 'builder-id';
+    service.accessToken = 'access-token';
+    service.expiresAt = new Date(Date.now() + 60_000).toISOString();
+    service.region = 'us-east-1';
+    service.axiosInstance = {
+        request: async () => ({
+            data: {
+                profiles: [
+                    { arn: 'arn:aws:codewhisperer:us-east-1:123456789012:profile/REAL' }
+                ]
+            }
+        })
+    };
+    service.saveCredentialsToFile = async () => {
+        throw new Error('read-only credential file');
+    };
+
+    const arn = await service.ensureProfileArn();
+
+    assert.equal(arn, 'arn:aws:codewhisperer:us-east-1:123456789012:profile/REAL');
+    assert.equal(service.profileArn, arn);
+    disposeService(service);
+});
+
 test('discovers and persists a missing IdC profileArn', async () => {
     const credentialPath = '/tmp/kiro-test.json';
     const service = new KiroApiService({ KIRO_OAUTH_CREDS_FILE_PATH: credentialPath });
     service.authMethod = 'builder-id';
     service.accessToken = 'access-token';
+    service.expiresAt = new Date(Date.now() + 60_000).toISOString();
     service.region = 'us-east-1';
     const requests = [];
     service.axiosInstance = {
@@ -53,7 +232,39 @@ test('discovers and persists a missing IdC profileArn', async () => {
     disposeService(service);
 });
 
-test('includes an existing profileArn in getUsageLimits for Builder ID', async () => {
+test('omits the Builder ID placeholder profileArn from getUsageLimits', async () => {
+    const service = new KiroApiService({});
+    service.isInitialized = true;
+    service.authMethod = 'builder-id';
+    service.accessToken = 'access-token';
+    service.expiresAt = new Date(Date.now() + 60 * 60_000).toISOString();
+    service.baseUrl = 'https://q.us-east-1.amazonaws.com/generateAssistantResponse';
+    service.region = 'us-east-1';
+    const requests = [];
+    service.axiosInstance = {
+        request: async (config) => {
+            requests.push(config);
+            if (config.headers?.['x-amz-target'] === 'AmazonCodeWhispererService.ListAvailableProfiles') {
+                const error = new Error('Request failed with status code 403');
+                error.response = {
+                    status: 403,
+                    data: { message: 'AWS Builder ID is not supported for this operation.' }
+                };
+                throw error;
+            }
+            return { data: { usedCount: 1, limitCount: 10 } };
+        }
+    };
+
+    await service.getUsageLimits();
+
+    assert.equal(service.profileArn, 'arn:aws:codewhisperer:us-east-1:638616132270:profile/AAAACCCCXXXX');
+    assert.equal(requests.length, 2);
+    assert.doesNotMatch(requests[1].url, /profileArn=/);
+    disposeService(service);
+});
+
+test('includes an existing real profileArn in getUsageLimits for Builder ID', async () => {
     const service = new KiroApiService({});
     service.isInitialized = true;
     service.authMethod = 'builder-id';

--- a/tests/kiro-profile-arn.node.test.mjs
+++ b/tests/kiro-profile-arn.node.test.mjs
@@ -1,0 +1,76 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { KiroApiService } from '../src/providers/claude/claude-kiro.js';
+
+function disposeService(service) {
+    if (service?.keepAliveAgent) service.keepAliveAgent.destroy();
+    if (service?.keepAliveAgentHttps) service.keepAliveAgentHttps.destroy();
+}
+
+test('includes an existing profileArn for Builder ID generation requests', async () => {
+    const service = new KiroApiService({});
+    service.authMethod = 'builder-id';
+    service.profileArn = 'arn:aws:codewhisperer:us-east-1:123456789012:profile/REAL';
+
+    const request = await service.buildCodewhispererRequest(
+        [{ role: 'user', content: 'hello' }],
+        'claude-sonnet-4-5'
+    );
+
+    assert.equal(request.profileArn, service.profileArn);
+    disposeService(service);
+});
+
+test('discovers and persists a missing IdC profileArn', async () => {
+    const credentialPath = '/tmp/kiro-test.json';
+    const service = new KiroApiService({ KIRO_OAUTH_CREDS_FILE_PATH: credentialPath });
+    service.authMethod = 'builder-id';
+    service.accessToken = 'access-token';
+    service.region = 'us-east-1';
+    const requests = [];
+    service.axiosInstance = {
+        request: async (config) => {
+            requests.push(config);
+            return {
+                status: 200,
+                data: {
+                    profiles: [
+                        { arn: 'arn:aws:codewhisperer:us-east-1:123456789012:profile/REAL' }
+                    ]
+                }
+            };
+        }
+    };
+    const writes = [];
+    service.saveCredentialsToFile = async (...args) => writes.push(args);
+
+    const arn = await service.ensureProfileArn();
+
+    assert.equal(arn, 'arn:aws:codewhisperer:us-east-1:123456789012:profile/REAL');
+    assert.equal(service.profileArn, arn);
+    assert.deepEqual(writes, [[credentialPath, { profileArn: arn }]]);
+    assert.equal(requests.length, 1);
+    disposeService(service);
+});
+
+test('includes an existing profileArn in getUsageLimits for Builder ID', async () => {
+    const service = new KiroApiService({});
+    service.isInitialized = true;
+    service.authMethod = 'builder-id';
+    service.accessToken = 'access-token';
+    service.profileArn = 'arn:aws:codewhisperer:us-east-1:123456789012:profile/REAL';
+    service.baseUrl = 'https://q.us-east-1.amazonaws.com/generateAssistantResponse';
+    service.region = 'us-east-1';
+    const requests = [];
+    service.axiosInstance = {
+        request: async (config) => {
+            requests.push(config);
+            return { data: { usedCount: 1, limitCount: 10 } };
+        }
+    };
+
+    await service.getUsageLimits();
+
+    assert.match(requests[0].url, new RegExp(`profileArn=${encodeURIComponent(service.profileArn)}`));
+    disposeService(service);
+});


### PR DESCRIPTION
## Summary

- send an existing real `profileArn` for Kiro generation and usage requests regardless of OAuth login type
- discover a missing Enterprise / IdC ARN through `ListAvailableProfiles`
- handle AWS Builder ID's unsupported discovery response with Kiro's request-scoped Builder ID profile ARN
- omit the Builder ID placeholder from `getUsageLimits`, while preserving real discovered ARNs
- refresh an expired/stale discovery token once and retry without losing the normal region fallback
- treat credential persistence as best-effort after successful discovery

## Background

Starting around Aug 25 01:00, IdC credentials could refresh their tokens but returned:

```text
403 User is not authorized to make this call.
```

Those credentials were missing `profileArn`, and A2 only sent that field for Social auth. Resolving and including the real ARN restored HTTP 200 responses.

A Builder ID user then reported that profile discovery itself returns:

```text
AWS Builder ID is not supported for this operation.
```

Builder ID and Enterprise / IdC therefore require different handling:

- streaming generation uses Kiro's Builder ID placeholder when discovery is unsupported;
- `getUsageLimits` does not send that placeholder;
- real discovered ARNs are sent to both request paths.

## Tests

```text
npm run test:kiro-profile-arn
10 passed, 0 failed
```

Regression coverage verifies:

- generation includes an existing ARN
- exact Builder ID discovery rejection uses the fixed generation ARN
- expired tokens refresh before discovery
- unexpected discovery 401 refreshes and retries once
- unrelated 403 responses are not treated as Builder ID
- repeated 401s refresh at most once across region fallback
- successful discovery remains usable if credential persistence fails
- Enterprise / IdC discovery persists a real ARN
- Builder ID placeholder is omitted from `getUsageLimits`
- real ARNs remain included in `getUsageLimits`

Sabotage runs were performed:

- restoring the pre-fix profile discovery behavior failed 5 regression tests;
- restoring unconditional `getUsageLimits` ARN inclusion failed the Builder ID usage regression test.

The repository-wide `npm test -- --runInBand` requires a running HTTP server. Both this branch and `upstream/main` report the same existing 30 integration failures without that server.

Fixes #699
