### PR TITLE
fix(kiro): 为 IdC 凭证解析 profileArn，修复 403 AccessDenied

### DIFF
--- a/src/providers/claude/claude-kiro.js
+++ b/src/providers/claude/claude-kiro.js
@@ -36,9 +36,12 @@ const KIRO_CONSTANTS = {
     REFRESH_IDC_URL: 'https://oidc.{{region}}.amazonaws.com/token',
     BASE_URL: 'https://q.{{region}}.amazonaws.com/generateAssistantResponse',
     BASE_RUNTIME_URL: 'https://q.{{region}}.amazonaws.com/generateAssistantResponse',
+    // 路径大小写敏感，小写会返回 UnknownOperationException
+    LIST_PROFILES_URL: 'https://codewhisperer.{{region}}.amazonaws.com/ListAvailableProfiles',
     DEFAULT_MODEL_NAME: 'claude-sonnet-4-5',
     AXIOS_TIMEOUT: 120000, // 2 minutes timeout for normal requests
     TOKEN_REFRESH_TIMEOUT: 15000, // 15 seconds timeout for token refresh (shorter to avoid blocking)
+    LIST_PROFILES_TIMEOUT: 10000, // 凭证装载期同步 await，不能久等
     USER_AGENT: 'KiroIDE',
     KIRO_VERSION: '0.11.63', //升级到新版本会导致aws用不了，需要找新接口
     CONTENT_TYPE_JSON: 'application/json',
@@ -839,8 +842,108 @@ async loadCredentials() {
         this.refreshUrl = (this.config.KIRO_REFRESH_URL || KIRO_CONSTANTS.REFRESH_URL).replace("{{region}}", this.region);
         this.refreshIDCUrl = (this.config.KIRO_REFRESH_IDC_URL || KIRO_CONSTANTS.REFRESH_IDC_URL).replace("{{region}}", this.idcRegion);
         this.baseUrl = (this.config.KIRO_BASE_URL || defaultBaseUrl).replace("{{region}}", this.region);
+
+        // profileArn 与上面的 region / baseUrl 同属凭证装载期的派生，下游不再判断登录方式。
+        await this._ensureProfileArn(isSocialAuth);
     } catch (error) {
         logger.warn(`[Kiro Auth] Error during credential loading: ${error.message}`);
+    }
+}
+
+/**
+ * 解析 this.profileArn（唯一决策点）。
+ * profileArn 是 CodeWhisperer 的订阅归属标识，缺失时上游返回 403 AccessDeniedException。
+ * social 凭证由 Kiro auth 服务随刷新响应下发该字段；IdC / builder-id 走 AWS SSO OIDC，
+ * 响应不包含它，需自行查询。
+ * @param {boolean} isSocialAuth
+ * @private
+ */
+async _ensureProfileArn(isSocialAuth) {
+    if (typeof this.profileArn === 'string' && this.profileArn.trim() !== '') {
+        return;
+    }
+
+    // social token 非 AWS 签发，ListAvailableProfiles 对它不适用；缺失时原样交给下游。
+    if (isSocialAuth) {
+        return;
+    }
+
+    // 发现结果由 _doTokenRefresh 的回写落入凭证文件，每份凭证通常只需发现一次。
+    const discovered = await this._discoverProfileArn();
+    if (discovered) {
+        this.profileArn = discovered;
+        logger.info(`[Kiro Auth] profileArn discovered: ${discovered}`);
+    }
+}
+
+/**
+ * 查询当前 token 可用的 profile。该接口不需要 profileArn，可用于自举。
+ * 失败返回 null 而不抛错：调用方在凭证装载路径上，抛错会阻塞初始化；包装异常还会
+ * 丢掉 status，使上层按状态码分流的重试 / 切凭证失效。
+ * @returns {Promise<string|null>}
+ * @private
+ */
+async _discoverProfileArn() {
+    // 无可用 token 时调用必然失败；刷新后的下一次 loadCredentials 会重试。
+    if (!this.accessToken || this.isTokenExpired()) {
+        logger.debug('[Kiro Auth] Skip profileArn discovery: no usable access token yet.');
+        return null;
+    }
+
+    const url = KIRO_CONSTANTS.LIST_PROFILES_URL.replace('{{region}}', this.region);
+    const machineId = generateMachineIdFromConfig({
+        uuid: this.uuid,
+        profileArn: this.profileArn,
+        clientId: this.clientId
+    });
+    const { osName, nodeVersion } = getSystemRuntimeInfo();
+    const kiroVersion = KIRO_CONSTANTS.KIRO_VERSION;
+
+    const axiosConfig = {
+        method: 'post',
+        url,
+        data: { maxResults: 10 },
+        timeout: KIRO_CONSTANTS.LIST_PROFILES_TIMEOUT,
+        headers: {
+            'Content-Type': KIRO_CONSTANTS.CONTENT_TYPE_JSON,
+            'Accept': KIRO_CONSTANTS.ACCEPT_JSON,
+            'Authorization': `Bearer ${this.accessToken}`,
+            'amz-sdk-invocation-id': uuidv4(),
+            'amz-sdk-request': 'attempt=1; max=1',
+            'x-amz-user-agent': `aws-sdk-js/1.0.34 KiroIDE-${kiroVersion}-${machineId}`,
+            'user-agent': `aws-sdk-js/1.0.34 ua/2.1 os/${osName} lang/js md/nodejs#${nodeVersion} api/codewhisperer#1.0.34 m/E KiroIDE-${kiroVersion}-${machineId}`,
+            'Connection': 'close'
+        }
+    };
+    this._applySidecar(axiosConfig);
+
+    try {
+        const response = await axios.request(axiosConfig);
+        const profiles = response.data?.profiles;
+        if (!Array.isArray(profiles) || profiles.length === 0) {
+            logger.warn('[Kiro Auth] ListAvailableProfiles returned no profiles.');
+            return null;
+        }
+
+        // 优先取与当前 region 匹配的，否则回退到第一个
+        const matched = profiles.find(p => p?.arn && typeof p.arn === 'string' && p.arn.includes(`:${this.region}:`));
+        const picked = matched || profiles.find(p => p?.arn);
+        if (!picked?.arn) {
+            logger.warn('[Kiro Auth] ListAvailableProfiles returned profiles without arn.');
+            return null;
+        }
+
+        if (profiles.length > 1) {
+            const all = profiles.map(p => p?.arn).filter(Boolean).join(', ');
+            logger.info(`[Kiro Auth] ${profiles.length} profiles available [${all}], selected ${picked.profileName || picked.arn}.`);
+        }
+        return picked.arn;
+    } catch (error) {
+        // 静默降级，由上层的 403 处理接手。
+        const status = error.response?.status;
+        const detail = error.response?.data?.message || error.message;
+        logger.warn(`[Kiro Auth] profileArn discovery failed${status ? ` (HTTP ${status})` : ''}: ${detail}`);
+        return null;
     }
 }
 
@@ -1732,7 +1835,9 @@ async saveCredentialsToFile(filePath, newData) {
             }
         }
 
-        if (this.authMethod === KIRO_CONSTANTS.AUTH_METHOD_SOCIAL) {
+        // != null 而非 truthy：social 凭证可能把 profileArn 落地成空串
+        // （kiro-oauth.js 的 `data.profileArn || ''`），保持请求体不变。
+        if (this.profileArn != null) {
             request.profileArn = this.profileArn;
         }
 
@@ -2215,9 +2320,9 @@ async saveCredentialsToFile(filePath, newData) {
         try {
             // Verify usage limits to confirm quota exhaustion
             const usageLimits = await this.getUsageLimits();
-            const isQuotaExhausted = usageLimits?.usedCount >= usageLimits?.limitCount;
-            
-            logger.info(`[Kiro] Quota confirmed exhausted: ${usageLimits?.usedCount}/${usageLimits?.limitCount}`);
+            // 真实响应字段为 usageBreakdownList[].currentUsage / usageLimit
+            const breakdown = usageLimits?.usageBreakdownList?.[0];
+            logger.info(`[Kiro] Quota confirmed exhausted: ${breakdown?.currentUsage}/${breakdown?.usageLimit}`);
             // Calculate recovery time: 1st day of next month at 00:00:00 UTC
             const nextMonth = this._getNextMonthFirstDay();
             this._markCredentialUnhealthyWithRecovery(verifiedReason, error, nextMonth);
@@ -3627,7 +3732,7 @@ async saveCredentialsToFile(filePath, newData) {
             origin: KIRO_CONSTANTS.ORIGIN_AI_EDITOR,
             resourceType: resourceType
         });
-         if (this.authMethod === KIRO_CONSTANTS.AUTH_METHOD_SOCIAL && this.profileArn) {
+        if (this.profileArn) {
             params.append('profileArn', this.profileArn);
         }
         const fullUrl = `${usageLimitsUrl}?${params.toString()}`;


### PR DESCRIPTION
Refs #699 — 该 issue 覆盖 IdC 与 Builder ID 两类身份，本 PR 只解决 IdC / Enterprise 一侧，因此用 `Refs` 而非 `Fixes`（Builder ID 见文末说明）。

相关：#701 提出过同一根因的修复（已 closed，未合入）。本 PR 与其在收口位置、失败处理与是否内置 ARN 上有实质差异，详见文末对比。

## 问题

IdC / builder-id 凭证的 `claude-kiro-oauth` 节点所有请求返回：

```
403 AccessDeniedException: User is not authorized to make this call.
```

节点因此被反复标记不健康。

根因是 CodeWhisperer 要求请求携带 `profileArn`（订阅归属标识），而该字段此前只在 social 登录时携带：

```js
if (this.authMethod === KIRO_CONSTANTS.AUTH_METHOD_SOCIAL) {
    request.profileArn = this.profileArn;
}
```

social 登录走 Kiro 自有 auth 服务，刷新响应直接下发 `profileArn`，凭证文件里自带。IdC / builder-id 走标准 AWS SSO OIDC，响应不含该字段，凭证文件里也没有，同目录的 client registration 文件同样只有 `{clientId, clientSecret, expiresAt}` —— 整条凭证链上都不产出它。

错误信息容易误导排查方向：服务端返回 `AccessDeniedException` 而非 `ValidationException`，看起来像账号或订阅问题，实际是缺少一个请求字段。

## 定位依据

用同一份 IdC 凭证做双侧对照（手工构造请求，绕过应用）：

| 调用 | 不带 profileArn | 带 profileArn |
|---|---|---|
| `getUsageLimits` | 403 AccessDenied | 200，返回订阅信息 |
| `generateAssistantResponse` | 403 AccessDenied | 200，正常响应 |

`ListAvailableProfiles` 不需要 `profileArn` 即可调用并返回 200，同时证明了 token 有效、账号正常，且给出了缺失值本身 —— 可用于自举。

## 改动

在 `loadCredentials()` 末尾收口解析 `profileArn`，与既有的 `region` / `idcRegion` / `baseUrl` 兜底推导并列（同属凭证装载期的派生）：

1. 凭证自带则采用；
2. social 原样跳过 —— 其 token 非 AWS 签发，`ListAvailableProfiles` 对它不适用；
3. 否则调用 `ListAvailableProfiles` 现场发现。

两处消费点（`buildCodewhispererRequest`、`getUsageLimits`）改为按数据存在性携带，不再判断 `authMethod`，改动后这两处对 `authMethod` 的引用从 2 处降到 0 处。

发现结果由 `_doTokenRefresh` 既有的回写逻辑落入凭证文件（`profileArn` 本就是该文件格式的合法字段），因此每份凭证通常只需发现一次，进程重启后不再重复查询。

### 几处刻意的取舍

**发现失败一律 `return null`，不抛错、不包装异常。** 调用方在凭证装载路径上，抛错会阻塞初始化；而把 axios error 包装成 `new Error(...)` 会丢掉 `status`，使上层基于状态码分流的重试 / 429 冷却 / 切换凭证分支全部失效。失败时行为与改动前一致（不携带该字段），由既有的 403 处理接手。

**无可用 token 时直接跳过发现**（`!this.accessToken || this.isTokenExpired()`）。此时调用必然失败，跳过可避免一次纯浪费的往返；token 刷新完成后的下一次 `loadCredentials` 会自然重试。

**消费点用 `!= null` 而非 truthy 判断。** `kiro-oauth.js` 存在 `profileArn: data.profileArn || ''`，空串是可能出现的值。原代码在 social 分支下是无条件赋值，改成 truthy 判断会让空串场景从"发送空串"变成"不发送字段"。用 `!= null` 保证请求体与改动前逐字节一致。

**不引入任何新配置项。** `profileArn` 是 CodeWhisperer 内部的订阅标识，用户在任何界面上都看不到它，唯一获取途径就是发现接口本身 —— 做成手工配置项无法填写。

**URL 路径大小写敏感**：`/ListAvailableProfiles` 有效，小写 `/listAvailableProfiles` 返回 `UnknownOperationException`（已在常量处注明）。

## 顺带修正

`_handle402Error` 中验证用量的日志字段名有误：

```js
- logger.info(`Quota confirmed exhausted: ${usageLimits?.usedCount}/${usageLimits?.limitCount}`);
+ const breakdown = usageLimits?.usageBreakdownList?.[0];
+ logger.info(`Quota confirmed exhausted: ${breakdown?.currentUsage}/${breakdown?.usageLimit}`);
```

实测 `getUsageLimits` 的真实响应顶层键为 `['daysUntilReset','limits','nextDateReset','overageConfiguration','subscriptionInfo','totalUsage','usageBreakdown','usageBreakdownList','userInfo']`，不存在 `usedCount` / `limitCount`，原代码会打出 `undefined/undefined`。

这一处与本 PR 相关而非无关改动：该分支此前不可达 —— `getUsageLimits` 在缺少 `profileArn` 时必然 403 而走 `catch`，修好后它才首次真正执行。同时被赋值后从未使用的 `isQuotaExhausted` 一并移除（两个分支都无条件调用 `_markCredentialUnhealthyWithRecovery`，恢复时间一致，功能无变化）。

## 验证

- 上游对照实验：`ListAvailableProfiles` 与 `getUsageLimits` 均实测 200，字段形状以真实响应为准。
- 独立脚本走真实代码路径（不启动服务）：11 项行为断言覆盖三级优先级、守卫（无 token / token 过期均不发请求）、失败降级（401/403/429/500 一律返回 null 且不抛错）、以及消费点的空值语义（`undefined` / `''` / 已解析三种情况）。
- 服务端到端：健康检查 PASSED，真实流式与非流式请求 200，节点状态 `isHealthy=True errorCount=0 refreshCount=0 lastErrorMessage=None`。
- 发现路径与复用路径分别验证：首次启动出现 `profileArn discovered: arn:aws:codewhisperer:...`；该值随首次 token 刷新落盘后，再次重启不再触发发现。

**未能验证的部分**（如实说明）：

- **AWS Builder ID**：该身份类型调用 `ListAvailableProfiles` 会返回 `403 AWS Builder ID is not supported for this operation`，本 PR 对其表现为发现失败后静默降级（行为与改动前一致，仍会 403）。我没有 Builder ID 凭证，无法实测，也未在本 PR 中为其添加特殊处理 —— 那属于另一个问题，需要单独解决。
- **social 登录路径**：无该类凭证可测。兼容性通过代码审查论证：`_ensureProfileArn` 在 `isSocialAuth` 时早退，不读取任何新配置、不发起任何请求；消费点用 `!= null` 保持请求体不变。

## 范围

单文件，`+110 / -5`。未改动任何共享模块（`provider-pool-manager.js`、`src/utils/` 等），未引入新的配置项、模块级状态或进程级缓存。


## 与 #699 / #701 的关系

**#699 的覆盖范围比本 PR 大。** 该 issue 下的报告者分属两类身份：

- **IdC / Enterprise** —— 凭证能刷新但不含 `profileArn`，补上即恢复 200。本 PR 解决这一类。
- **AWS Builder ID** —— `ListAvailableProfiles` 对其返回 `403 AWS Builder ID is not supported for this operation`，发现接口本身不可用。**本 PR 不解决这一类**，对它表现为发现失败后静默降级（行为与改动前一致）。

所以这里用 `Refs #699` 而不是 `Fixes #699` —— 合入本 PR 后，Builder ID 用户仍需另行处理，issue 不应被自动关闭。

**与 #701 的差异**（同一根因，方案不同）：

| | #701 | 本 PR |
|---|---|---|
| 收口位置 | `buildCodewhispererRequest` 与 `getUsageLimits` 两个消费点各调一次 `ensureProfileArn()` | `loadCredentials()` 末尾一处，与 `region` / `baseUrl` 派生并列 |
| 发现失败 | `throw new Error(...)` | `return null`，静默降级 |
| Builder ID | 内置一个固定 ARN 作占位符 | 不内置任何 ARN |
| 持久化 | 发现后主动 `saveCredentialsToFile` | 搭 `_doTokenRefresh` 既有回写 |

前两项差异有具体后果。收口在消费点意味着将来新增任何 CodeWhisperer 调用点都要记得补一次调用，漏了就是 403；而 `buildCodewhispererRequest` 位于 `callApi` / `streamApiReal` 的 `try` 块**之外**，在那里抛错会绕过既有的网络重试、429 冷却与切换凭证逻辑 —— #701 的 review 也指出了这一点（401 与其他可重试错误均被包装成普通 `Error`，丢失 `status`）。本 PR 因此选择在凭证装载期收口 + 失败返回 `null`。

Builder ID 那个固定 ARN 属于第三方账号下的 profile，维护者在 #701 中明确否决（"The ARN shouldn't be hardcoded."）。本 PR 不走这条路：Builder ID 应作为独立问题解决，可行方向是让上游确认该身份类型的正确取值来源，而不是让所有 Builder ID 用户共用一个来源不明的 ARN。
